### PR TITLE
chore: add CODEOWNERS for GeneDx org governance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @GeneDx/fabric


### PR DESCRIPTION
Bootstrap CODEOWNERS as part of the FabricGenomics -> GeneDx org migration. Required before the org Application ruleset is applied.

Runbook: plans/engineering/fabric-migration-integration/_reference/repo-org-migration-runbook.md